### PR TITLE
Add support for running tests in --watch mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ tests_require = ['six', 'pytest>=3.1.0', 'pytest-cov', 'nose', 'django>=1.10.6,<
 
 setup(
     name='snapshottest',
-    version='0.5.1+wave7',  # PEP 440 "local version identifier"
+    version='0.5.1+wave8',  # PEP 440 "local version identifier"
     description='Snapshot Testing utils for Python',
     long_description=readme,
     author='Syrus Akbary',

--- a/snapshottest/pytest.py
+++ b/snapshottest/pytest.py
@@ -105,6 +105,10 @@ def pytest_terminal_summary(terminalreporter):
 
     terminalreporter.config._snapshotsession.display(terminalreporter)
 
+    # Reset loaded snapshots at the end of the test session.
+    # Needed for running tests in watch mode.
+    SnapshotModule._snapshot_modules = {}
+
 
 @pytest.mark.trylast  # force the other plugins to initialise, fixes issue with capture not being properly initialised
 def pytest_configure(config):


### PR DESCRIPTION
Add support for running tests in --watch mode #2

Bump version

**Context**
[meili] snapshots tests working with –watch flag. In my experience in watch mode the actual data in the snapshot file are ignored and the test shouldn’t fail even if it should
From Devex papercut jam:
https://docs.google.com/document/d/1yZ10Zdwru3PWdIIJvnZIiClqBLvs9EVOIbFNvwDIGAU/edit#